### PR TITLE
Update git modules and fix tests

### DIFF
--- a/tests/Go.Tests.ps1
+++ b/tests/Go.Tests.ps1
@@ -58,7 +58,7 @@ Describe "Go" {
         "go run simple.go" | Should -ReturnZeroExitCode
         "go build simple.go" | Should -ReturnZeroExitCode
         $compiledPackageName = "simple"
-        if ($IsWindows) { $compiledPackageName = "simple.exe" }
+        if ($IsWindows) { $compiledPackageName += ".exe" }
         (Resolve-Path "./$compiledPackageName").Path | Should -ReturnZeroExitCode
     }
 
@@ -68,7 +68,7 @@ Describe "Go" {
         "go run maps.go" | Should -ReturnZeroExitCode
         "go build maps.go" | Should -ReturnZeroExitCode
         $compiledPackageName = "maps"
-        if ($IsWindows) { $compiledPackageName = "maps.exe" }
+        if ($IsWindows) { $compiledPackageName += ".exe" }
         (Resolve-Path "./$compiledPackageName").Path | Should -ReturnZeroExitCode
     }
 
@@ -78,7 +78,7 @@ Describe "Go" {
         "go run methods.go" | Should -ReturnZeroExitCode
         "go build methods.go" | Should -ReturnZeroExitCode
         $compiledPackageName = "methods"
-        if ($IsWindows) { $compiledPackageName = "methods.exe" }
+        if ($IsWindows) { $compiledPackageName += ".exe" }
         (Resolve-Path "./$compiledPackageName").Path | Should -ReturnZeroExitCode
     }
 }

--- a/tests/Go.Tests.ps1
+++ b/tests/Go.Tests.ps1
@@ -57,7 +57,9 @@ Describe "Go" {
         Set-Location -Path $simpleLocation
         "go run simple.go" | Should -ReturnZeroExitCode
         "go build simple.go" | Should -ReturnZeroExitCode
-        "./simple" | Should -ReturnZeroExitCode
+        $compiledPackageName = "simple"
+        if ($IsWindows) { $compiledPackageName = "simple.exe" }
+        (Resolve-Path "./$compiledPackageName").Path | Should -ReturnZeroExitCode
     }
 
     It "Run maps code" {
@@ -65,7 +67,9 @@ Describe "Go" {
         Set-Location -Path $mapsLocation
         "go run maps.go" | Should -ReturnZeroExitCode
         "go build maps.go" | Should -ReturnZeroExitCode
-        "./maps" | Should -ReturnZeroExitCode
+        $compiledPackageName = "maps"
+        if ($IsWindows) { $compiledPackageName = "maps.exe" }
+        (Resolve-Path "./$compiledPackageName").Path | Should -ReturnZeroExitCode
     }
 
     It "Run methods code" {
@@ -73,6 +77,8 @@ Describe "Go" {
         Set-Location -Path $methodsLocation
         "go run methods.go" | Should -ReturnZeroExitCode
         "go build methods.go" | Should -ReturnZeroExitCode
-        "./methods" | Should -ReturnZeroExitCode
+        $compiledPackageName = "methods"
+        if ($IsWindows) { $compiledPackageName = "methods.exe" }
+        (Resolve-Path "./$compiledPackageName").Path | Should -ReturnZeroExitCode
     }
 }


### PR DESCRIPTION
We recently changed the `ShouldReturnZeroExitCode` function in `helpers/pester-extensions.psm1` script and this caused issues in GO tests. In scope of this PR, we fixed these issues and updated git modules to the latest version.