### PR TITLE
Fix PowerShell issue with relative paths

### DIFF
--- a/builders/build-go.ps1
+++ b/builders/build-go.ps1
@@ -1,5 +1,5 @@
-using module "./builders/win-go-builder.psm1"
-using module "./builders/nix-go-builder.psm1"
+using module "./win-go-builder.psm1"
+using module "./nix-go-builder.psm1"
 
 <#
 .SYNOPSIS

--- a/builders/nix-go-builder.psm1
+++ b/builders/nix-go-builder.psm1
@@ -1,4 +1,4 @@
-using module "./builders/go-builder.psm1"
+using module "./go-builder.psm1"
 
 class NixGoBuilder : GoBuilder {
     <#

--- a/builders/win-go-builder.psm1
+++ b/builders/win-go-builder.psm1
@@ -1,4 +1,4 @@
-using module "./builders/go-builder.psm1"
+using module "./go-builder.psm1"
 
 class WinGoBuilder : GoBuilder {
     <#


### PR DESCRIPTION
PowerShell 7.1.0 introduces breaking changes that affect relative paths. Go packages generation fails with the following error:
```
The specified module '/home/runner/work/go-versions/go-versions/builders/builders/win-go-builder.psm1' was not loaded because no valid module file was found in any module directory.
```

In scope of this PR we prepared fix for this issue.

Related issue: [#1473](https://github.com/actions/virtual-environments-internal/issues/1473)