### PR TITLE
config: update version regex to support Go's initial minor releases

### DIFF
--- a/config/go-manifest-config.json
+++ b/config/go-manifest-config.json
@@ -1,5 +1,5 @@
 {
-    "regex": "go-\\d+\\.\\d+\\.\\d+-(\\w+)-(x\\d+)",
+    "regex": "go-\\d+\\.\\d+(?:\\.\\d+)-(\\w+)-(x\\d+)",
     "groups": {
         "arch": 2,
         "platform": 1


### PR DESCRIPTION
Go doesn't _really_ follow semver here: the initial release of a new
minor series does not end with .0, which means there's no Go 1.16.0,
it's actually Go 1.16.

This is me trying to fix actions/setup-go#105, not sure if this is
correct.