### PR TITLE
Move get-go-versions pipeline from Azure DevOps

### DIFF
--- a/.github/workflows/get-go-versions.yml
+++ b/.github/workflows/get-go-versions.yml
@@ -1,0 +1,72 @@
+name: Get Go versions
+on:
+  schedule:
+    - cron: '0 3,15 * * *'
+  workflow_dispatch:
+
+env:
+  TOOL_NAME: "Go"
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  find_new_versions:
+    name: Find new versions
+    runs-on: ubuntu-18.04
+    outputs:
+      versions_output: ${{ steps.Get_new_versions.outputs.version_number }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - id: Get_new_versions
+        name: Get new versions
+        run: ./helpers/get-new-tool-versions/get-new-tool-versions.ps1 -ToolName ${{ env.TOOL_NAME }}
+
+  check_new_versions:
+    name: Check new versions
+    runs-on: ubuntu-18.04
+    needs: find_new_versions
+    env:
+      TOOL_VERSIONS: ${{needs.find_new_versions.outputs.versions_output}}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Check Versions
+        if: success() && env.TOOL_VERSIONS == ''
+        run: |
+          Write-Host "No new versions were found"
+          Import-Module "./helpers/github/github-api.psm1"
+          $gitHubApi = Get-GitHubApi -RepositoryFullName "$env:GITHUB_REPOSITORY" `
+                                     -AccessToken "${{ secrets.PERSONAL_TOKEN }}"
+          $gitHubApi.CancelWorkflow("$env:GITHUB_RUN_ID")
+          Start-Sleep -Seconds 60
+      - name: Send Slack notification
+        run: |
+          $PipelineUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          ./helpers/get-new-tool-versions/send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
+                                                                      -ToolName "${{ env.TOOL_NAME }}" `
+                                                                      -ToolVersion "${{ env.TOOL_VERSIONS }}" `
+                                                                      -PipelineUrl "$PipelineUrl" `
+                                                                      -ImageUrl "https://golang.org/lib/godoc/images/footer-gopher.jpg"
+  trigger_builds:
+    name: Trigger builds
+    runs-on: ubuntu-18.04
+    needs: [find_new_versions, check_new_versions]
+    env:
+      TOOL_VERSIONS: ${{needs.find_new_versions.outputs.versions_output}}
+    environment: Get Available Tools Versions - Publishing Approval
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Trigger "Build go packages" workflow
+        run:
+          ./helpers/github/run-ci-builds.ps1 -RepositoryFullName "$env:GITHUB_REPOSITORY" `
+                                             -AccessToken "${{ secrets.PERSONAL_TOKEN }}" `
+                                             -WorkflowFileName "build-go-packages.yml" `
+                                             -WorkflowDispatchRef "main" `
+                                             -ToolVersions "${{ env.TOOL_VERSIONS }}" `
+                                             -PublishReleases "true"


### PR DESCRIPTION
In scope of this PR we moved [get-go-versions](https://github.visualstudio.com/virtual-environments/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=77&nonce=KmafEwrcwq3RhMpb3BjsIw%3D%3D&branch=main) pipeline from Azure DevOps to this repository.

Work item: https://github.com/actions/virtual-environments-internal/issues/2412