### PR TITLE
Add back slack notification

### DIFF
--- a/.github/workflows/get-go-versions.yml
+++ b/.github/workflows/get-go-versions.yml
@@ -51,7 +51,10 @@ jobs:
         run: |
           $pipelineUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
           $message = "The following versions of '${{ env.TOOL_NAME }}' are available to upload: ${{ env.TOOL_VERSIONS }}\nLink to the pipeline: $pipelineUrl"
-          echo "$message"
+          ./helpers/get-new-tool-versions/send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
+                                                                      -ToolName "${{ env.TOOL_NAME }}" `
+                                                                      -ImageUrl "https://golang.org/lib/godoc/images/footer-gopher.jpg" `
+                                                                      -Text "$message"
           
   trigger_builds:
     name: Trigger builds
@@ -88,4 +91,7 @@ jobs:
         run: |
           $pipelineUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
           $message = "The build of the '${{ env.TOOL_NAME }}' detection pipeline failed :progress-error:\nLink to the pipeline: $pipelineUrl"
-          echo "$message"
+          ./helpers/get-new-tool-versions/send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
+                                                                      -ToolName "${{ env.TOOL_NAME }}" `
+                                                                      -Text "$message" `
+                                                                      -ImageUrl "https://golang.org/lib/godoc/images/footer-gopher.jpg"


### PR DESCRIPTION
This PR reverts our temp [fix](https://github.com/actions/go-versions/pull/49) to get out our new go versions asap. 

We fixed our Slack webhook issues so we can put back this code in our workflow for notifying us of new versions, etc.