### PR TITLE
Fix for CodeQL analysis workflow failures

### DIFF
--- a/.github/workflows/build-go-packages.yml
+++ b/.github/workflows/build-go-packages.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   go:
     name: Go
-    uses: actions/versions-package-tools/.github/workflows/build-tool-packages.yml@main
+    uses: gowridurga.d/versions-package-tools/.github/workflows/build-tool-packages.yml@versions_changes
     with:
       tool-name: "go"
       tool-version: ${{ inputs.VERSION || '1.19.0' }}

--- a/.github/workflows/build-go-packages.yml
+++ b/.github/workflows/build-go-packages.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   go:
     name: Go
-    uses: gowridurgad/versions-package-tools/.github/workflows/build-tool-packages.yml@versions_changes
+    uses: actions/versions-package-tools/.github/workflows/build-tool-packages.yml@versions_changes
     with:
       tool-name: "go"
       tool-version: ${{ inputs.VERSION || '1.19.0' }}

--- a/.github/workflows/build-go-packages.yml
+++ b/.github/workflows/build-go-packages.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   go:
     name: Go
-    uses: actions/versions-package-tools/.github/workflows/build-tool-packages.yml@versions_changes
+    uses: actions/versions-package-tools/.github/workflows/build-tool-packages.yml@main
     with:
       tool-name: "go"
       tool-version: ${{ inputs.VERSION || '1.19.0' }}

--- a/.github/workflows/build-go-packages.yml
+++ b/.github/workflows/build-go-packages.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   go:
     name: Go
-    uses: gowridurga.d/versions-package-tools/.github/workflows/build-tool-packages.yml@versions_changes
+    uses: gowridurgad/versions-package-tools/.github/workflows/build-tool-packages.yml@versions_changes
     with:
       tool-name: "go"
       tool-version: ${{ inputs.VERSION || '1.19.0' }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,4 +13,4 @@ jobs:
     name: CodeQL analysis 
     uses: actions/reusable-workflows/.github/workflows/codeql-analysis.yml@main
     with:
-      languages: "['go']"
+      languages: '["go"]'


### PR DESCRIPTION
This PR will resolve the CodeQL analysis failures in setup-actions repositories.

This change modifies the default value for the languages input in the CodeQL check step. Previously, the value was set to default: "['javascript']". However, this format causes a parsing error because JSON requires double quotes (") for strings. The updated line default: '["javascript"]' fixes this issue by using double quotes for the array values, as required by JSON.